### PR TITLE
Fix regex to work on macOS

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -62,22 +62,22 @@ make isa
 # Test CKB VM with riscv-tests
 # NOTE: let's stick with the simple way here since we know there won't be
 # whitespaces, otherwise shell might not be a good option here.
-for i in $(find . -regex ".*/rv32u[imc]-u-[a-z0-9_]+" | grep -v "fence_i"); do
+for i in $(find . -regex ".*/rv32u[imc]-u-[a-z0-9_]*" | grep -v "fence_i"); do
     $INTERPRETER32 $i
 done
-for i in $(find . -regex ".*/rv64u[imc]-u-[a-z0-9_]+" | grep -v "fence_i"); do
+for i in $(find . -regex ".*/rv64u[imc]-u-[a-z0-9_]*" | grep -v "fence_i"); do
     $INTERPRETER64 $i
 done
-for i in $(find . -regex ".*/rv64u[imc]-u-[a-z0-9_]+" | grep -v "fence_i" | grep -v "rv64ui-u-jalr"); do
+for i in $(find . -regex ".*/rv64u[imc]-u-[a-z0-9_]*" | grep -v "fence_i" | grep -v "rv64ui-u-jalr"); do
     $ASM64 $i
 done
-for i in $(find . -regex ".*/rv64u[imc]-u-[a-z0-9_]+" | grep -v "fence_i" | grep -v "rv64ui-u-jalr"); do
+for i in $(find . -regex ".*/rv64u[imc]-u-[a-z0-9_]*" | grep -v "fence_i" | grep -v "rv64ui-u-jalr"); do
     $AOT64 $i
 done
-for i in $(find . -regex ".*/rv64u[imc]-u-[a-z0-9_]+" | grep -v "fence_i"); do
+for i in $(find . -regex ".*/rv64u[imc]-u-[a-z0-9_]*" | grep -v "fence_i"); do
     $ASM64_VERSION1 $i
 done
-for i in $(find . -regex ".*/rv64u[imc]-u-[a-z0-9_]+" | grep -v "fence_i"); do
+for i in $(find . -regex ".*/rv64u[imc]-u-[a-z0-9_]*" | grep -v "fence_i"); do
     $AOT64_VERSION1 $i
 done
 


### PR DESCRIPTION
For whatever reason this particular regex is returning no results with OSX's BSD userspace, and changing the `+` to `*` fixes the problem without changing the meaning too much.

Tested on mac and linux.